### PR TITLE
List only files that match imageTypes regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ module.exports = function (opts) {
                 list.forEach(function (name) {
                     var stats = fs.statSync(options.uploadDir + '/' + name),
                         fileInfo;
-                    if (stats.isFile() && name[0] !== '.') {
+                    if (stats.isFile() && name[0] !== '.' && options.imageTypes.test(name)) {
                         fileInfo = new FileInfo({
                             name: name,
                             size: stats.size


### PR DESCRIPTION
If you manually create files in your `uploadDir` folder, they are listed by the `get` method.
This test ignores all other files such as log files, Thumbs.db etc...
