### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "dependencies": {
     "formidable": "^1.0.14",
     "mkdirp": "^0.5.0",
-    "jasmine-node": "^1.14.3",
     "aws-sdk": "^2.0.0-rc.19"
   },
+  "devDependencies": {
+    "jasmine-node": "1.14.2",
+  }
   "repository": {
     "type": "git",
     "url": "https://github.com/arvindr21/blueimp-file-upload-expressjs.git"


### PR DESCRIPTION
- Moved `jasmine-node` to `devDependencies` section
- Downgraded `jasmine-node` to 1.14.2 according to https://github.com/larrymyers/jasmine-reporters/issues/63
