### PR TITLE
fix initializing without imageVersions set

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,11 +46,13 @@ module.exports = function(opts) {
       }
     };
 
-  Object.keys(opts.imageVersions).forEach(function(version) {
-    if (version != 'maxHeight' && version != 'maxWidth') {
-      options.imageVersions[version] = opts.imageVersions[version];
-    }
-  });
+  if (opts.imageVersions) {
+    Object.keys(opts.imageVersions).forEach(function(version) {
+      if (version != 'maxHeight' && version != 'maxWidth') {
+        options.imageVersions[version] = opts.imageVersions[version];
+      }
+    });
+  }
 
 
   if (options.storage.type === "local") {


### PR DESCRIPTION
[Demo](http://thejackalofjavascript.com/uploading-files-made-fun/) says, that minimal options are these:

```
var options = {
    tmpDir:  __dirname + '/../public/uploaded/tmp',
    uploadDir: __dirname + '/../public/uploaded/files',
    uploadUrl:  '/uploaded/files/',
    storage : {
        type : 'local'
    }
};
```

But when you initialize the module without `imageVersions` an error occurs:

```
.../blueimp-file-upload-expressjs/index.js:50
    Object.keys(opts.imageVersions).forEach(function(version) {
           ^
TypeError: Object.keys called on non-object
```

This simple PR fixes this issue with checking for `opts.imageVersions` before working with it.
