### PR TITLE
Height "auto" doesn't work

### DIFF
--- a/lib/transport/local.js
+++ b/lib/transport/local.js
@@ -51,7 +51,7 @@ module.exports = function(opts){
                     
                     retVal.width = opts0.width;
                     retVal.height = (opts0.width/retVal.fileInfo.width) * retVal.fileInfo.height;
-                    image.batch().resize(opts0.width).writeFile(options.uploadDir + '/' + versionObj.version + '/' + versionObj.fileInfo.name, function(err) {
+                    image.batch().resize(opts0.width, retVal.height).writeFile(options.uploadDir + '/' + versionObj.version + '/' + versionObj.fileInfo.name, function(err) {
                         if (err) {
                             cbk(err,retVal);
                             return;


### PR DESCRIPTION
Use the height previously computed to resize image if height was defined as auto