### PR TITLE
AWS transport fixed and added new features

### DIFF
--- a/lib/transport/aws.js
+++ b/lib/transport/aws.js
@@ -62,6 +62,7 @@ module.exports = function (opts){
             this.upload(fileInfo.name, file.path, function(error,awsFile) {
                 if(!error){
                     fileInfo.awsFile = awsFile;
+                    fileInfo.proccessed = true;
                     fileInfo.initUrls();
                 }
                 finish(error,fileInfo);

--- a/lib/transport/aws.js
+++ b/lib/transport/aws.js
@@ -27,6 +27,7 @@ var FileInfo        = require('../fileinfo.js');
  *   http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property
  * @param {boolean} [opts.storage.aws.signedUrlExpiresSeconds=900] - For use
  *   with getSignedUrl=true.
+ * @param {string} [opts.storage.aws.path] - Path on bucket to store uploads
  *
  * @example
  * awsTransport({
@@ -40,7 +41,8 @@ var FileInfo        = require('../fileinfo.js');
  *       acl: 'public-read',
  *       cacheControl: 'max-age=630720000, public',
  *       expiresInMilliseconds: 63072000000,
- *       getSignedUrl: false
+ *       getSignedUrl: false,
+ *       path: 'uploads/'
  *     }
  *   }
  * });
@@ -160,7 +162,7 @@ function uploadFile(s3, fileName, filePath, opts, callback) {
   var params = {
     ACL: opts.acl,
     Bucket: opts.bucketName,
-    Key: remoteFilename,
+    Key: (opts.path || '') + remoteFilename,
     Body: fileBuffer,
     ContentType: metaData
   };
@@ -188,7 +190,7 @@ function uploadFile(s3, fileName, filePath, opts, callback) {
           Expires: opts.signedUrlExpires || 900
         });
     } else {
-        url = s3.endpoint.href + opts.bucketName + '/' + remoteFilename;
+        url = s3.endpoint.href + opts.bucketName + '/' + opts.path + remoteFilename;
     }
     
     callback(error,{ url: url});

--- a/lib/transport/aws.js
+++ b/lib/transport/aws.js
@@ -39,7 +39,8 @@ var FileInfo        = require('../fileinfo.js');
  *       bucketName: '...',
  *       acl: 'public-read',
  *       cacheControl: 'max-age=630720000, public',
- *       expiresInMilliseconds: 63072000000
+ *       expiresInMilliseconds: 63072000000,
+ *       getSignedUrl: false
  *     }
  *   }
  * });
@@ -154,7 +155,7 @@ function getContentTypeByFile(fileName) {
 
 function uploadFile(s3, fileName, filePath, opts, callback) {
   var fileBuffer = fs.readFileSync(filePath);
-  var metaData = getContentTypeByFile(filePath);
+  var metaData = getContentTypeByFile(fileName);
   var remoteFilename = b() + '__' + fileName;
   var params = {
     ACL: opts.acl,
@@ -187,7 +188,7 @@ function uploadFile(s3, fileName, filePath, opts, callback) {
           Expires: opts.signedUrlExpires || 900
         });
     } else {
-        url = remoteFilename;
+        url = s3.endpoint.href + opts.bucketName + '/' + remoteFilename;
     }
     
     callback(error,{ url: url});

--- a/lib/transport/aws.js
+++ b/lib/transport/aws.js
@@ -4,6 +4,46 @@
 var fs              = require('fs');
 var AWS             = require('aws-sdk');
 var FileInfo        = require('../fileinfo.js');
+
+/**
+ * AWS transport
+ *
+ * @param {Object} opts
+ * @param {Object} opts.storage
+ * @param {Object} opts.storage.aws
+ * @param {string} opts.storage.aws.accessKeyId
+ * @param {string} opts.storage.aws.secretAccessKey
+ * @param {string} opts.storage.aws.region
+ * @param {string} opts.storage.aws.bucketName
+ * @param {string} opts.storage.aws.acl
+ * @param {string} [opts.storage.aws.cacheControl] - Sets the S3 CacheControl
+ *   param.
+ * @param {Number} [opts.storage.aws.expiresInMilliseconds] - Sets the S3
+ *   Expires param with expiresInMilliseconds from the current time
+ * @param {boolean} [opts.storage.aws.getSignedUrl=true] - If set to true, the
+ *   upload callback will pass a signed URL of the file, that will expire in
+ *   signedUrlExpiresSeconds if set (default 900s = 15m). If set to false, the
+ *   callback will pass the actual URL. More info about the signed URL here:
+ *   http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property
+ * @param {boolean} [opts.storage.aws.signedUrlExpiresSeconds=900] - For use
+ *   with getSignedUrl=true.
+ *
+ * @example
+ * awsTransport({
+ *   storage: {
+ *     type: 'aws',
+ *     aws: {
+ *       accessKeyId: '...',
+ *       secretAccessKey: '...',
+ *       region: 'us-west-2',
+ *       bucketName: '...',
+ *       acl: 'public-read',
+ *       cacheControl: 'max-age=630720000, public',
+ *       expiresInMilliseconds: 63072000000
+ *     }
+ *   }
+ * });
+ */
 module.exports = function (opts){
 
     var configs = opts.storage.aws;
@@ -135,12 +175,20 @@ function uploadFile(s3, fileName, filePath, opts, callback) {
   }
 
   s3.putObject(params, function(error) {
-    var params = {
-      Bucket: opts.bucketName,
-      Key: remoteFilename
-    };
+    var url;
 
-    var url = s3.getSignedUrl('getObject', params);
+    if (typeof opts.getSignedUrl === 'undefined' || opts.getSignedUrl === true) {
+
+        // getSignedUrl documentation
+        // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property
+        url = s3.getSignedUrl('getObject', {
+          Bucket: opts.bucketName,
+          Key: remoteFilename,
+          Expires: opts.signedUrlExpires || 900
+        });
+    } else {
+        url = remoteFilename;
+    }
     
     callback(error,{ url: url});
   });

--- a/lib/transport/aws.js
+++ b/lib/transport/aws.js
@@ -116,14 +116,25 @@ function uploadFile(s3, fileName, filePath, opts, callback) {
   var fileBuffer = fs.readFileSync(filePath);
   var metaData = getContentTypeByFile(filePath);
   var remoteFilename = b() + '__' + fileName;
-
-  s3.putObject({
+  var params = {
     ACL: opts.acl,
     Bucket: opts.bucketName,
     Key: remoteFilename,
     Body: fileBuffer,
     ContentType: metaData
-  }, function(error) {
+  };
+
+  // consider setting params.CacheControl by default to 'max-age=630720000, public'
+  if (typeof opts.cacheControl !== 'undefined') {
+    params.CacheControl = opts.cacheControl;
+  }
+
+  // consider setting params.Expires by default to new Date(Date.now() + 63072000000)
+  if (typeof opts.expiresInMilliseconds !== 'undefined') {
+    params.Expires = new Date(Date.now() + opts.expiresInMilliseconds);
+  }
+
+  s3.putObject(params, function(error) {
     var params = {
       Bucket: opts.bucketName,
       Key: remoteFilename

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueimp-file-upload-expressjs",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "jQuery File Upload using Expressjs : 'borrowed' from Blueimp jQuery File Upload developed by Sebastian Tschan",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async": "^0.9.0",
     "aws-sdk": "^2.1.20",
     "formidable": "^1.0.17",
-    "lwip": "0.0.6",
+    "lwip": "~0.0.8",
     "mkdirp": "0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #45 and #46 

New features:
- now you can specify if you want a signed url (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property) or a never-expiring url of the uploaded file (useful for storing it on a db).
- now you can specify CacheControl and Expires params
- now you can specify a path on bucket where you want to store the uploaded files

This is an example of the new options (also documented on lib/transport/aws.js):
```javascript
options = {
   storage: {
     type: 'aws',
     aws: {
       accessKeyId: '...',
       secretAccessKey: '...',
       region: 'us-west-2',
       bucketName: '...',
       acl: 'public-read',
       cacheControl: 'max-age=630720000, public',
       expiresInMilliseconds: 63072000000,
       getSignedUrl: false,
       path: 'uploads/'
     }
   }
 }
```