### PR TITLE
properly check the mime types of a file

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -9,6 +9,7 @@ var options = {
     minFileSize: 1,
     maxFileSize: 10000000000, // 10 GB
     acceptFileTypes: /.+/i,
+    acceptMimeTypes: [],
     copyImgAsThumb: true,
     useSSL: false,
     UUIDRegex: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,

--- a/lib/fileinfo.js
+++ b/lib/fileinfo.js
@@ -85,6 +85,8 @@ FileInfo.prototype.validate = function() {
         this.error = 'File is too big';
     } else if (!this.options.acceptFileTypes.test(this.name)) {
         this.error = 'Filetype not allowed';
+    } else if (this.options.acceptMimeTypes.length && this.options.acceptMimeTypes.indexOf(this.type) === -1) {
+        this.error = "Filetype is not allowed";
     }
     return !this.error;
 };


### PR DESCRIPTION
Properly check the mime type of a file.  From the looks of it the acceptedFileTypes checks the file name and not the mime type.
